### PR TITLE
Switch to proguard 6.1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,7 @@ lazy val interface = project
       dest
     },
     addArtifact(artifact.in(Compile, packageBin), finalPackageBin),
+    proguardVersion.in(Proguard) := "6.1.1",
     proguardOptions.in(Proguard) ++= Seq(
       "-dontwarn",
       "-dontobfuscate",


### PR DESCRIPTION
Should make using the JAR of `io.get-coursier:interface` from JDK 11 fine, hopefully (proguard `6.1` [added support for JDK 10+](https://www.guardsquare.com/en/blog/proguard-61-released)).