### PR TITLE
Publish proguarded module built with scala 2.12 too

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,6 @@ lazy val finalPackageBin = taskKey[File]("")
 lazy val interface = project
   .enablePlugins(SbtProguard)
   .settings(
-    skip.in(publish) := scalaVersion.value != Settings.scala213,
     finalPackageBin := {
       import org.pantsbuild.jarjar._
       import org.pantsbuild.jarjar.util.StandaloneJarProcessor
@@ -109,7 +108,12 @@ lazy val interface = project
     ),
 
     autoScalaLibrary := false,
-    crossVersion := CrossVersion.disabled,
+    crossVersion := {
+      if (scalaVersion.value == Settings.scala213)
+        CrossVersion.disabled
+      else
+        CrossVersion.binary
+    },
 
     // filtering out non cross versioned module in 0.0.1 (published cross-versioned there, added below)
     mimaPreviousArtifacts := mimaPreviousArtifacts.value.filter(_.revision != "0.0.1"),


### PR DESCRIPTION
Published as `io.get-coursier:interface_2.12` (but doesn't depend on scala). This module shades then proguards scala 2.12 instead of 2.13, which can be preferred by some users down the line (when building GraalVM native images in particular).