### PR TITLE
replace junit with junit jupiter for java 9 and later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
         +mimaReportBinaryIssues
         'set version in ThisBuild := "'"${{ env.TEST_VERSION }}"'"'
         publishLocal
+      env:
+        JAVA_11_COMPAT: true
 
   publish:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env: 
+      TEST_VERSION: "0.1.0-test"
+    strategy:
+      matrix:
+        java: [8,11]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -18,10 +23,20 @@ jobs:
     - uses: coursier/cache-action@v6
     - uses: laughedelic/coursier-setup@v1
       with:
-        jvm: 8
+        jvm: ${{ matrix.java }}
         apps: sbt-launcher
-    - name: Test
-      run: ./.github/scripts/ci.sh
+    - name: Test on java 8
+      if: matrix.java == 8
+      run: >
+        sbt 
+        +test
+        +evictionCheck
+        +mimaReportBinaryIssues
+        'set version in ThisBuild := "'"${{ env.TEST_VERSION }}"'"'
+        publishLocal
+    - name: Test on java 11
+      if: matrix.java == 11
+      run: sbt test
 
   publish:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,13 @@ jobs:
         publishLocal
     - name: Test on java 11
       if: matrix.java == 11
-      run: sbt test
+      run: > 
+        sbt 
+        +test
+        +evictionCheck
+        +mimaReportBinaryIssues
+        'set version in ThisBuild := "'"${{ env.TEST_VERSION }}"'"'
+        publishLocal
 
   publish:
     needs: test

--- a/build.sbt
+++ b/build.sbt
@@ -79,9 +79,10 @@ lazy val interface = project
       "-dontwarn",
       "-dontobfuscate",
       "-dontoptimize",
-      "-keep class coursierapi.** {\n  public protected *;\n}",
-      s"-libraryjars ${sys.env("JAVA_HOME")}/jmods/java.base.jmod"
-    ),
+      "-keep class coursierapi.** {\n  public protected *;\n}"
+    ) ++ sys.env.get("JAVA_11_COMPAT")
+      .map(_=>s"-libraryjars ${sys.env("JAVA_HOME")}/jmods/java.base.jmod")
+      .toSeq,
     javaOptions.in(Proguard, proguard) := Seq("-Xmx3172M"),
 
     // Adding the interface JAR rather than its classes directory.
@@ -200,13 +201,6 @@ lazy val `interface-test` = project
       "org.junit.jupiter" % "junit-jupiter-api" % "5.7.0" % Test,
       "net.aichler" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test
     ),
-    libraryDependencies ++= {
-      val org = organization.in(interface).value
-      val name = moduleName.in(interface).value
-      sys.env.get("TEST_VERSION").toSeq.map { v =>
-        org % name % v
-      }
-    },
     unmanagedClasspath.in(Test) ++= Def.taskDyn {
       if (sys.env.get("TEST_VERSION").isEmpty)
         Def.task {
@@ -218,7 +212,7 @@ lazy val `interface-test` = project
     // suppress eviction check warning
     dependencyOverrides ++= Seq(
       "org.scala-lang" % "scala-library" % scalaVersion.value,
-      )
+    )
   )
 
 skip.in(publish) := true

--- a/build.sbt
+++ b/build.sbt
@@ -186,7 +186,7 @@ lazy val interpolators = project
       ProblemFilters.exclude[MissingClassProblem]("coursierapi.Interpolators$Macros$"),
     )
   )
-
+// to run tests locally, you must set a TEST_VERSION environment variable.
 lazy val `interface-test` = project
   .disablePlugins(MimaPlugin)
   .dependsOn(interface)
@@ -214,7 +214,11 @@ lazy val `interface-test` = project
 	}
       else
         Def.task(Seq.empty[File])
-    }.value
+    }.value,
+    // suppress eviction check warning
+    dependencyOverrides ++= Seq(
+      "org.scala-lang" % "scala-library" % scalaVersion.value,
+      )
   )
 
 skip.in(publish) := true

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ import com.typesafe.tools.mima.core.{MissingClassProblem, Problem, ProblemFilter
 import scala.xml.{Node => XmlNode, _}
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
+resolvers in ThisBuild += Resolver.jcenterRepo
+
 inThisBuild(List(
   organization := "io.get-coursier",
   homepage := Some(url("https://github.com/coursier/interface")),
@@ -78,6 +80,8 @@ lazy val interface = project
       "-dontobfuscate",
       "-dontoptimize",
       "-keep class coursierapi.** {\n  public protected *;\n}",
+      // tmp
+      // "-libraryjars /path/to/jmods/java.base.jmod"
     ),
     javaOptions.in(Proguard, proguard) := Seq("-Xmx3172M"),
 
@@ -193,8 +197,9 @@ lazy val `interface-test` = project
     autoScalaLibrary := false,
     crossVersion := CrossVersion.disabled,
     libraryDependencies ++= Seq(
-      "junit" % "junit" % "4.13.2" % Test,
-      "com.novocode" % "junit-interface" % "0.11" % Test
+      "org.junit.jupiter" % "junit-jupiter" % "5.7.0" % Test,
+      "org.junit.jupiter" % "junit-jupiter-api" % "5.7.0" % Test,
+      "net.aichler" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test
     ),
     libraryDependencies ++= {
       val org = organization.in(interface).value

--- a/build.sbt
+++ b/build.sbt
@@ -73,15 +73,14 @@ lazy val interface = project
       dest
     },
     addArtifact(artifact.in(Compile, packageBin), finalPackageBin),
-    proguardVersion.in(Proguard) := "7.1.0-beta3",
+    proguardVersion.in(Proguard) := "7.1.0",
     proguardOptions.in(Proguard) ++= Seq(
       "-dontnote",
       "-dontwarn",
       "-dontobfuscate",
       "-dontoptimize",
       "-keep class coursierapi.** {\n  public protected *;\n}",
-      // tmp
-      // "-libraryjars /path/to/jmods/java.base.jmod"
+      s"-libraryjars ${sys.env("JAVA_HOME")}/jmods/java.base.jmod"
     ),
     javaOptions.in(Proguard, proguard) := Seq("-Xmx3172M"),
 
@@ -119,7 +118,7 @@ lazy val interface = project
 
     Settings.shared,
     Settings.mima(),
-    libraryDependencies += "io.get-coursier" %% "coursier" % "2.0.15",
+    libraryDependencies += "io.get-coursier" %% "coursier" % "2.0.16",
 
     libraryDependencies += "com.lihaoyi" %% "utest" % "0.7.7" % Test,
     testFrameworks += new TestFramework("utest.runner.Framework"),
@@ -190,7 +189,7 @@ lazy val interpolators = project
 
 lazy val `interface-test` = project
   .disablePlugins(MimaPlugin)
-  // .dependsOn(interface)
+  .dependsOn(interface)
   .settings(
     Settings.shared,
     skip.in(publish) := true,

--- a/interface-test/src/test/java/coursierapi/test/CompleteTests.java
+++ b/interface-test/src/test/java/coursierapi/test/CompleteTests.java
@@ -3,8 +3,8 @@ package coursierapi.test;
 import coursierapi.Complete;
 import coursierapi.CompleteResult;
 import coursierapi.error.CoursierError;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.*;
 

--- a/interface-test/src/test/java/coursierapi/test/FetchTests.java
+++ b/interface-test/src/test/java/coursierapi/test/FetchTests.java
@@ -4,8 +4,8 @@ import coursierapi.Dependency;
 import coursierapi.Fetch;
 import coursierapi.FetchResult;
 import coursierapi.error.CoursierError;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.util.*;

--- a/interface-test/src/test/java/coursierapi/test/VersionsTests.java
+++ b/interface-test/src/test/java/coursierapi/test/VersionsTests.java
@@ -2,8 +2,8 @@ package coursierapi.test;
 
 import coursierapi.*;
 import coursierapi.error.CoursierError;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDateTime;
 import java.util.*;

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,11 @@ addSbtPlugin("io.github.alexarchambault.sbt" % "sbt-eviction-rules" % "0.2.0")
 addSbtPlugin("com.github.alexarchambault.tmp" % "sbt-mima-plugin" % "0.7.1-SNAPSHOT")
 addSbtPlugin("com.lightbend.sbt" % "sbt-proguard" % "0.4.0")
 
+resolvers += Resolver.jcenterRepo
+
+addSbtPlugin("net.aichler" % "sbt-jupiter-interface" % "0.8.4")
+
+
 resolvers += Resolver.sonatypeRepo("snapshots")
 
 libraryDependencies += "com.eed3si9n.jarjarabrams" %% "jarjar-abrams-core" % "0.3.0"


### PR DESCRIPTION
I'm going to replace junit  with junit 5(junit jupiter ) for Java 9 and later compatibility.

note: -libraryJars  path/to/javahome/jmods is necesarry to avoid the error below.
```
proguard.evaluation.IncompleteClassHierarchyException
Can't find common super class of [coursier.util.Sync] (with 1 known super classes: coursier.util.Sync) and [scala.collection.immutable.Seq] (with 1 known super classes: scala.collection.immutable.Seq))
```