### PR TITLE
Make withScalaVersion also set Scala Binary Version in Complete

### DIFF
--- a/interface/src/main/scala/coursier/internal/api/ApiHelper.scala
+++ b/interface/src/main/scala/coursier/internal/api/ApiHelper.scala
@@ -418,10 +418,11 @@ object ApiHelper {
       .map(repository)
       .toVector
 
+    val binVersionOpt = Option(complete.getScalaBinaryVersion)
     val res = coursier.complete.Complete(cache0)
       .withRepositories(repositories)
-      .withScalaBinaryVersionOpt(Option(complete.getScalaBinaryVersion))
-      .withScalaVersionOpt(Option(complete.getScalaVersion))
+      .withScalaBinaryVersionOpt(binVersionOpt)
+      .withScalaVersionOpt(Option(complete.getScalaVersion), binVersionOpt.isEmpty)
       .withInput(complete.getInput)
       .complete()
       .unsafeRun()(cache0.ec)


### PR DESCRIPTION
Hi, I don't know if this is intended, but I saw that:
```scala
Complete.create().withScalaVersion("foobar")
```
Does not appear to also set the scala binary version (with the ultimate effect I don't get completions after `::`), I had a quick look in the coursier source and looks like it's because `.withScalaVersionOpt(Option[String])` is used instead of `.withScalaVersionOpt(Option[String], Boolean)`?

Let me know if that makes sense, thanks ~ Laurence.

