### PR TITLE
map default repositories to api classes

### DIFF
--- a/interface/src/main/scala/coursier/internal/api/ApiHelper.scala
+++ b/interface/src/main/scala/coursier/internal/api/ApiHelper.scala
@@ -20,13 +20,9 @@ import scala.collection.JavaConverters._
 
 object ApiHelper {
 
-  private[this] final case class ApiRepo(repo: Repository) extends coursierapi.Repository
-
   def defaultRepositories(): Array[coursierapi.Repository] =
     Resolve.defaultRepositories
-      .map { repo =>
-        ApiRepo(repo)
-      }
+      .map(repository(_))
       .toArray
 
   def ivy2Local(): coursierapi.IvyRepository = {
@@ -153,7 +149,6 @@ object ApiHelper {
 
   def repository(repo: coursierapi.Repository): Repository =
     repo match {
-      case ApiRepo(repo0) => repo0
       case mvn: coursierapi.MavenRepository =>
         MavenRepository(
           mvn.getBase,

--- a/interface/src/main/scala/coursier/internal/api/ApiHelper.scala
+++ b/interface/src/main/scala/coursier/internal/api/ApiHelper.scala
@@ -20,6 +20,8 @@ import scala.collection.JavaConverters._
 
 object ApiHelper {
 
+  private[this] final case class ApiRepo(repo: Repository) extends coursierapi.Repository
+
   def defaultRepositories(): Array[coursierapi.Repository] =
     Resolve.defaultRepositories
       .map(repository(_))
@@ -149,6 +151,7 @@ object ApiHelper {
 
   def repository(repo: coursierapi.Repository): Repository =
     repo match {
+      case ApiRepo(repo0) => repo0
       case mvn: coursierapi.MavenRepository =>
         MavenRepository(
           mvn.getBase,
@@ -179,7 +182,7 @@ object ApiHelper {
           .withMetadataPattern(mdPatternOpt.orNull)
           .withCredentials(credentialsOpt.orNull)
       case other =>
-        throw new Exception(s"Unrecognized repository: " + other)
+        ApiRepo(other)
     }
 
   def resolutionParams(params: ResolutionParams): coursierapi.ResolutionParams = {


### PR DESCRIPTION
Previously: `defaultRepositories` were wrapped in a private `ApiRepo` class. Now: `defaultRepositories` are mapped to their api equivalences. reason:
It seems that ApiRepo is not really used for anything else and there is a method that can core.Repository to api.Repository. Without this change we cannot extract any information from `defaultRepositories` using this interface.